### PR TITLE
Use strongly typed AuthorizedKeyTypes

### DIFF
--- a/src/openssh/v2/constants.rs
+++ b/src/openssh/v2/constants.rs
@@ -1,0 +1,6 @@
+pub const ECDSA_SHA2_NISTP256: &str = "ecdsa-sha2-nistp256";
+pub const ECDSA_SHA2_NISTP384: &str = "ecdsa-sha2-nistp384";
+pub const ECDSA_SHA2_NISTP521: &str = "ecdsa-sha2-nistp521";
+pub const SSH_ED25519: &str = "ssh-ed25519";
+pub const SSH_DSS: &str = "ssh-dss";
+pub const SSH_RSA: &str = "ssh-rsa";

--- a/src/openssh/v2/display.rs
+++ b/src/openssh/v2/display.rs
@@ -1,4 +1,5 @@
-use super::models::{AuthorizedKey, AuthorizedKeysFile, AuthorizedKeysFileLine};
+use super::constants::*;
+use super::models::{AuthorizedKey, AuthorizedKeyType, AuthorizedKeysFile, AuthorizedKeysFileLine};
 use std::fmt::{Display, Error, Formatter};
 
 impl Display for AuthorizedKey {
@@ -30,14 +31,31 @@ impl Display for AuthorizedKeysFile {
     }
 }
 
+impl Display for AuthorizedKeyType {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        write!(
+            f,
+            "{}",
+            match self {
+                AuthorizedKeyType::EcdsaSha2Nistp256 => ECDSA_SHA2_NISTP256,
+                AuthorizedKeyType::EcdsaSha2Nistp384 => ECDSA_SHA2_NISTP384,
+                AuthorizedKeyType::EcdsaSha2Nistp521 => ECDSA_SHA2_NISTP521,
+                AuthorizedKeyType::SshEd25519 => SSH_ED25519,
+                AuthorizedKeyType::SshDss => SSH_DSS,
+                AuthorizedKeyType::SshRsa => SSH_RSA,
+            }
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::AuthorizedKey;
+    use super::{AuthorizedKey, AuthorizedKeyType};
 
     #[test]
     fn it_writes_a_key() {
         let mut subject = AuthorizedKey::default();
-        subject.key_type = "ssh-ed25519".to_owned();
+        subject.key_type = AuthorizedKeyType::SshEd25519;
         subject.encoded_key =
             "AAAAC3NzaC1lZDI1NTE5AAAAIGgqo1o+dOHqeIc7A5MG53s5iYwpMQm7f3hnn+uxtHUM".to_owned();
 
@@ -50,7 +68,7 @@ mod tests {
     #[test]
     fn it_writes_a_key_with_comments() {
         let mut subject = AuthorizedKey::default();
-        subject.key_type = "ssh-ed25519".to_owned();
+        subject.key_type = AuthorizedKeyType::SshEd25519;
         subject.encoded_key =
             "AAAAC3NzaC1lZDI1NTE5AAAAIGgqo1o+dOHqeIc7A5MG53s5iYwpMQm7f3hnn+uxtHUM".to_owned();
         subject.comments = " the quick brown fox jumped over the lazy dog   ".to_owned();
@@ -64,7 +82,7 @@ mod tests {
         subject
             .options
             .push(("no-agent-forwarding".to_owned(), None));
-        subject.key_type = "ssh-ed25519".to_owned();
+        subject.key_type = AuthorizedKeyType::SshEd25519;
         subject.encoded_key =
             "AAAAC3NzaC1lZDI1NTE5AAAAIGgqo1o+dOHqeIc7A5MG53s5iYwpMQm7f3hnn+uxtHUM".to_owned();
 
@@ -88,7 +106,7 @@ mod tests {
             "environment".to_owned(),
             Some("LOGNAME=ssh-user".to_owned()),
         ));
-        subject.key_type = "ssh-ed25519".to_owned();
+        subject.key_type = AuthorizedKeyType::SshEd25519;
         subject.encoded_key =
             "AAAAC3NzaC1lZDI1NTE5AAAAIGgqo1o+dOHqeIc7A5MG53s5iYwpMQm7f3hnn+uxtHUM".to_owned();
         subject.comments = "this is a more complex example".to_owned();

--- a/src/openssh/v2/edit.rs
+++ b/src/openssh/v2/edit.rs
@@ -71,7 +71,7 @@ impl AuthorizedKey {
     }
 
     /// Sets the key type to the provided value.
-    pub fn key_type(mut self, val: String) -> Self {
+    pub fn key_type(mut self, val: AuthorizedKeyType) -> Self {
         self.key_type = val;
 
         self
@@ -94,7 +94,7 @@ impl AuthorizedKey {
 
 #[cfg(test)]
 mod tests {
-    use super::AuthorizedKey;
+    use super::{AuthorizedKey, AuthorizedKeyType};
 
     #[test]
     fn it_adds_options() {
@@ -111,23 +111,19 @@ mod tests {
 
         assert_eq!(
             &subject.to_string(),
-            r#"command="echo \"hello, world!\"",baz,command="echo \"goodbye, world!\""  "#
+            r#"command="echo \"hello, world!\"",baz,command="echo \"goodbye, world!\"" ssh-rsa "#
         )
     }
 
     #[test]
     fn it_removes_options() {
-        let subject = AuthorizedKey {
-            options: vec![
-                ("foo".to_owned(), Some("bar".to_owned())),
-                ("foo".to_owned(), Some("baz".to_owned())),
-                ("foo".to_owned(), None),
-                ("quz".to_owned(), None),
-            ],
-            key_type: "".to_owned(),
-            encoded_key: "".to_owned(),
-            comments: "".to_owned(),
-        };
+        let mut subject = AuthorizedKey::default();
+        subject.options = vec![
+            ("foo".to_owned(), Some("bar".to_owned())),
+            ("foo".to_owned(), Some("baz".to_owned())),
+            ("foo".to_owned(), None),
+            ("quz".to_owned(), None),
+        ];
 
         assert_eq!(1, subject.clone().remove_named_options("foo").options.len());
         assert_eq!(
@@ -167,10 +163,10 @@ mod tests {
     #[test]
     fn it_sets_key_parameters() {
         let subject = AuthorizedKey::default()
-            .key_type("ssh-rsa".to_owned())
+            .key_type(AuthorizedKeyType::SshRsa)
             .encoded_key("thisisvalidbase64/==".to_owned());
 
-        assert_eq!("ssh-rsa", subject.key_type);
+        assert_eq!(AuthorizedKeyType::SshRsa, subject.key_type);
         assert_eq!("thisisvalidbase64/==", subject.encoded_key);
     }
 

--- a/src/openssh/v2/get.rs
+++ b/src/openssh/v2/get.rs
@@ -29,12 +29,12 @@ impl AuthorizedKey {
 
 #[cfg(test)]
 mod tests {
-    use super::AuthorizedKey;
+    use super::{AuthorizedKey, AuthorizedKeyType};
 
     #[test]
     fn it_gets_key_def() {
         let mut subject = AuthorizedKey::default();
-        subject.key_type = "ecdsa-sha2-nistp256".to_owned();
+        subject.key_type = AuthorizedKeyType::EcdsaSha2Nistp256;
         subject.encoded_key = "morevalidbase64please+==".to_owned();
 
         assert_eq!(

--- a/src/openssh/v2/mod.rs
+++ b/src/openssh/v2/mod.rs
@@ -1,5 +1,6 @@
 //! Formats and functions for OpenSSH v2 `authorized_keys` files
 
+mod constants;
 mod display;
 mod edit;
 mod get;

--- a/src/openssh/v2/models.rs
+++ b/src/openssh/v2/models.rs
@@ -16,14 +16,37 @@ pub type KeyOption = (String, Option<String>);
 /// `AuthorizedKey`.
 pub type KeyOptions = Vec<KeyOption>;
 
+/// Represents the key type of an authorized public key
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthorizedKeyType {
+    /// `ecdsa-sha2-nistp256`
+    EcdsaSha2Nistp256,
+    /// `ecdsa-sha2-nistp384`
+    EcdsaSha2Nistp384,
+    /// `ecdsa-sha2-nistp521`
+    EcdsaSha2Nistp521,
+    /// `ssh-ed25519`
+    SshEd25519,
+    /// `ssh-dss` (for DSA)
+    SshDss,
+    /// `ssd-rsa`
+    SshRsa,
+}
+
+impl Default for AuthorizedKeyType {
+    fn default() -> Self {
+        AuthorizedKeyType::SshRsa
+    }
+}
+
 /// Represents the format of a key in an OpenSSH v2 `authorized_keys`
 /// file.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct AuthorizedKey {
     /// Options applied to the key
     pub options: KeyOptions,
-    /// Type of key (e.g. `ssh-rsa`)
-    pub key_type: String,
+    /// Type of key (e.g. `ssh-rsa` -> `AuthorizedKeyType::SshRsa`)
+    pub key_type: AuthorizedKeyType,
     /// Public key, base64 encoded
     pub encoded_key: String,
     /// Comments written at the end of the `authorized_keys` line


### PR DESCRIPTION
Instead of accepting a specific list of `key_type` in the grammar, but allowing any string value when setting, use a strongly typed Enum of key types.